### PR TITLE
Add new database column

### DIFF
--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -12,6 +12,7 @@ interface ItemCardProps {
   imageUrl?: string;
   type: "lost" | "found";
   createdAt: string;
+  tags?: string[];
   onContactClick: () => void;
 }
 
@@ -24,6 +25,7 @@ export const ItemCard = ({
   type,
   createdAt,
   onContactClick,
+  tags,
 }: ItemCardProps) => {
   return (
     <Card 
@@ -66,6 +68,11 @@ export const ItemCard = ({
           <Badge variant="outline" className="text-xs">
             {category}
           </Badge>
+          {tags && tags.length > 0 && tags.slice(0, 3).map((tag) => (
+            <Badge key={tag} variant="secondary" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
           {location && (
             <div className="flex items-center gap-1 text-xs text-muted-foreground">
               <MapPin className="h-3 w-3" />

--- a/src/components/ReportItemDialog.tsx
+++ b/src/components/ReportItemDialog.tsx
@@ -33,6 +33,7 @@ export const ReportItemDialog = ({ open, onOpenChange, type, onSuccess }: Report
   const [category, setCategory] = useState("");
   const [location, setLocation] = useState("");
   const [contactInfo, setContactInfo] = useState("");
+  const [tags, setTags] = useState<string>("");
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -86,6 +87,10 @@ export const ReportItemDialog = ({ open, onOpenChange, type, onSuccess }: Report
           location,
           contact_info: contactInfo,
           image_url: imageUrl,
+          tags: tags
+            .split(',')
+            .map((t) => t.trim())
+            .filter((t) => t.length > 0),
         })
         .select('*')
         .single();
@@ -118,6 +123,7 @@ export const ReportItemDialog = ({ open, onOpenChange, type, onSuccess }: Report
       setCategory("");
       setLocation("");
       setContactInfo("");
+      setTags("");
       setImageFile(null);
     } catch (error) {
       console.error("Error submitting item:", error);
@@ -193,6 +199,16 @@ export const ReportItemDialog = ({ open, onOpenChange, type, onSuccess }: Report
               onChange={(e) => setContactInfo(e.target.value)}
               placeholder="Email or phone number"
               required
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="tags">Tags (comma-separated)</Label>
+            <Input
+              id="tags"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+              placeholder="e.g., blue, backpack, library"
             />
           </div>
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -24,6 +24,7 @@ export type Database = {
           image_url: string | null
           location: string | null
           resolved_at: string | null
+          tags: string[]
           status: string
           title: string
           type: string
@@ -39,6 +40,7 @@ export type Database = {
           image_url?: string | null
           location?: string | null
           resolved_at?: string | null
+          tags?: string[]
           status?: string
           title: string
           type: string
@@ -54,6 +56,7 @@ export type Database = {
           image_url?: string | null
           location?: string | null
           resolved_at?: string | null
+          tags?: string[]
           status?: string
           title?: string
           type?: string

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -23,6 +23,7 @@ export type Database = {
           id: string
           image_url: string | null
           location: string | null
+          resolved_at: string | null
           status: string
           title: string
           type: string
@@ -37,6 +38,7 @@ export type Database = {
           id?: string
           image_url?: string | null
           location?: string | null
+          resolved_at?: string | null
           status?: string
           title: string
           type: string
@@ -51,6 +53,7 @@ export type Database = {
           id?: string
           image_url?: string | null
           location?: string | null
+          resolved_at?: string | null
           status?: string
           title?: string
           type?: string

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,6 +20,7 @@ interface Item {
   image_url: string | null;
   type: "lost" | "found";
   created_at: string;
+  tags?: string[];
 }
 
 const CATEGORIES = [
@@ -190,6 +191,7 @@ const Index = () => {
                 imageUrl={item.image_url || undefined}
                 location={item.location || undefined}
                 description={item.description || undefined}
+                tags={item.tags}
                 createdAt={item.created_at}
                 onContactClick={() => handleItemClick(item)}
               />

--- a/src/pages/MyItems.tsx
+++ b/src/pages/MyItems.tsx
@@ -72,7 +72,7 @@ const MyItems = () => {
     try {
       const { error } = await supabase
         .from('items')
-        .update({ status: 'resolved' })
+        .update({ status: 'resolved', resolved_at: new Date().toISOString() })
         .eq('id', id);
 
       if (error) throw error;

--- a/src/pages/MyItems.tsx
+++ b/src/pages/MyItems.tsx
@@ -18,6 +18,7 @@ interface Item {
   type: "lost" | "found";
   created_at: string;
   status: string;
+  tags?: string[];
 }
 
 const MyItems = () => {

--- a/supabase/migrations/1759658062_add-resolved-at-to-items.sql
+++ b/supabase/migrations/1759658062_add-resolved-at-to-items.sql
@@ -1,0 +1,3 @@
+-- Add nullable timestamp column resolved_at to public.items
+ALTER TABLE public.items
+ADD COLUMN IF NOT EXISTS resolved_at timestamptz;

--- a/supabase/migrations/1759658554_add-tags-to-items.sql
+++ b/supabase/migrations/1759658554_add-tags-to-items.sql
@@ -1,0 +1,3 @@
+-- Add tags column as text[] with default empty array
+ALTER TABLE public.items
+ADD COLUMN IF NOT EXISTS tags text[] NOT NULL DEFAULT '{}';


### PR DESCRIPTION
Add `resolved_at` column to the `public.items` table and set it when an item is marked as resolved.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0cf791e-bd08-46b1-a837-864e7335cad5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0cf791e-bd08-46b1-a837-864e7335cad5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Items can include tags; you can add tags when reporting an item and see up to three tag badges on item cards.
  * Marking an item as resolved now records the exact resolve timestamp for clearer history and auditing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->